### PR TITLE
Enforce golint and go fmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - checkout
       - run: brew install go
       - run: go get ./...
+      - run: golint ./...
       - run: cd whiteblock && go build
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - checkout
       - run: brew install go
       - run: go get ./...
+      - run: sh /.circleci/fmt.sh
       - run: golint ./...
       - run: cd whiteblock && go build
       - persist_to_workspace:

--- a/.circleci/fmt.sh
+++ b/.circleci/fmt.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd whiteblock
+
+if [ -n "$(gofmt -l .)" ]; then
+    echo "Go code is not formatted:"
+    gofmt -d .
+    exit 1
+else
+ echo "Go code is well formatted"
+fi

--- a/whiteblock/cmd/get.go
+++ b/whiteblock/cmd/get.go
@@ -494,6 +494,14 @@ var getBiomeCmd = &cobra.Command{
 	},
 }
 
+var getBoxCmd = &cobra.Command{
+	Use: "box",
+	Short: "Get box information",
+	Run: func(cmd *cobra.Command, args []string) {
+		util.Print(conf.ServerAddr)
+	},
+}
+
 var getContractsCmd = &cobra.Command{
 	Use:   "contracts",
 	Short: "Get contracts deployed to network.",
@@ -520,7 +528,7 @@ func init() {
 	getNodesCmd.Flags().Bool("all", false, "output all of the nodes, even if they are no longer running")
 
 	getCmd.AddCommand(getServerCmd, getNodesCmd, getStatsCmd, getDefaultsCmd,
-		getSupportedCmd, getRunningCmd, getConfigsCmd, getTestnetIDCmd, getBuildCmd, getPrivateKeysCmd)
+		getSupportedCmd, getRunningCmd, getConfigsCmd, getTestnetIDCmd, getBuildCmd, getPrivateKeysCmd, getBoxCmd)
 
 	getStatsCmd.AddCommand(statsByTimeCmd, statsByBlockCmd, statsPastBlocksCmd, statsAllCmd)
 


### PR DESCRIPTION
adds enforcement for golint and go fmt

**note** leaving a pr open so an admin can hook up circleci per @n8wb 's instruction. 